### PR TITLE
Fix : Padding Issue in TUIMobileOverlayMenuItem when there is no Leading Icon provide

### DIFF
--- a/tarka-ui/build.gradle.kts
+++ b/tarka-ui/build.gradle.kts
@@ -66,7 +66,7 @@ publishing {
       run {
         groupId = "com.tarkalabs"
         artifactId = getLibraryArtifactId()
-        version = "1.1.15"
+        version = "1.1.16"
         artifact("$buildDir/outputs/aar/tarka-ui-release.aar")
       }
     }

--- a/tarka-ui/src/main/java/com/tarkalabs/tarkaui/components/TUIMobileOverlayMenuItem.kt
+++ b/tarka-ui/src/main/java/com/tarkalabs/tarkaui/components/TUIMobileOverlayMenuItem.kt
@@ -106,7 +106,7 @@ sealed class MobileOverlayMenuItemStyle {
     }
   } else {
     {
-      HorizontalSpacer(space = 48)
+      HorizontalSpacer(space = 16)
     }
   }
 


### PR DESCRIPTION
### What was Implemented/Fixed 📚
- proper padding used in TUIMobileOverlayMenuItem when there is no leadingIcon Provided.

### Links to tickets/documentation 🔗
- [Figma UI](https://www.figma.com/design/qVIpQXgoO3SW1RDWmnwmLK/EAM-360-Technician-Team-Version?node-id=37696-112119&t=m2W38uajbPgMvfXD-4)

### How it Was Implemented 🔦
[proper padding used in TUIMobileOverlayMenuItem when there is no leadingIcon Provided](https://github.com/tarkalabs/tarka-ui-kit-android/commit/a7dc9ba0c40ad75d5070b2e6113f2655b56c2cd7) 

### How can a reviewer test this change 🧑‍💻
- Run Preview & check with Figma

### Testing checks / How Has This Been Tested ✅
- [x] I have tested my changes locally

## Screenshots & Video🖼️\

FIGMA :
<img width="334" alt="Screenshot 2024-05-17 at 10 24 18 AM" src="https://github.com/tarkalabs/eam360-technician-android/assets/99186954/c4ec89b1-f731-4bbb-a8cc-9c77f8e5a0de">

Before :
<img width="258" alt="Inspection Select Value BottomSheet"
src="https://github.com/tarkalabs/eam360-technician-android/assets/99186954/0821c98a-50df-427f-bc4a-0c37ab7fdacb" />

After : 
<img width ="258" src="https://github.com/tarkalabs/eam360-technician-android/assets/99186954/2bdee66d-fcbb-466b-94b7-bf6ce1defe02"/>