### PR TITLE
initial Focus made as optional in TUISearchBar

### DIFF
--- a/tarka-ui/build.gradle.kts
+++ b/tarka-ui/build.gradle.kts
@@ -66,7 +66,7 @@ publishing {
       run {
         groupId = "com.tarkalabs"
         artifactId = getLibraryArtifactId()
-        version = "1.1.21"
+        version = "1.1.22"
         artifact("$buildDir/outputs/aar/tarka-ui-release.aar")
       }
     }

--- a/tarka-ui/src/main/java/com/tarkalabs/tarkaui/components/TUISearchBar.kt
+++ b/tarka-ui/src/main/java/com/tarkalabs/tarkaui/components/TUISearchBar.kt
@@ -44,13 +44,16 @@ import kotlinx.coroutines.delay
   onQueryTextChange: (String) -> Unit,
   leadingIcon: TarkaIcon? = null,
   onLeadingIconClick: (() -> Unit)? = null,
+  isInitialAutoFocus: Boolean = true,
   searchBarTags: TUISearchBarTags = TUISearchBarTags(),
 ) {
   val focusRequester = remember { FocusRequester() }
 
-  LaunchedEffect(Unit) {
-    delay(500)
-    focusRequester.requestFocus()
+  LaunchedEffect(isInitialAutoFocus) {
+    if(isInitialAutoFocus) {
+      delay(500)
+      focusRequester.requestFocus()
+    }
   }
 
   val leadingIconLambda: @Composable (() -> Unit)? = if (leadingIcon != null) {

--- a/tarka-ui/src/main/java/com/tarkalabs/tarkaui/components/TUISearchBar.kt
+++ b/tarka-ui/src/main/java/com/tarkalabs/tarkaui/components/TUISearchBar.kt
@@ -50,7 +50,7 @@ import kotlinx.coroutines.delay
   val focusRequester = remember { FocusRequester() }
 
   LaunchedEffect(isInitialAutoFocus) {
-    if(isInitialAutoFocus) {
+    if (isInitialAutoFocus) {
       delay(500)
       focusRequester.requestFocus()
     }


### PR DESCRIPTION
### What was Implemented/Fixed 📚
- previously we automatically focused the searchBar TextField but now as per the Inspection Details UI Requirements it's not needed so it is made as optional.

### How it Was Implemented 🔦
separate boolean key was introduced.

### How can a reviewer test this change 🧑‍💻
- Run the Preview 

### Testing checks / How Has This Been Tested ✅
- [x] I have tested my changes locally
